### PR TITLE
Update sample tfvars file to avoid warning

### DIFF
--- a/devops_oke/terraform.tfvars.example
+++ b/devops_oke/terraform.tfvars.example
@@ -4,11 +4,8 @@ user_ocid            = "ocid1.user.oc1.."
 fingerprint          = "1c.."
 private_key_path     = "~/.oci/oci_api_key.pem"
 
-# SSH Keys
-ssh_public_key  = "~/.oci/key.pub"
-
 # Region
 region = "us-ashburn-1"
 
 # Compartment
-compartment_ocid = "ocid1.compartment.oc1."
+compartment_id = "ocid1.compartment.oc1."


### PR DESCRIPTION
Without this fix, the user would get the following warning.

Warning: Value for undeclared variable
│
│ The root module does not declare a variable named "compartment_ocid" but a value was found in file
│ "terraform.tfvars". If you meant to use this value, add a "variable" block to the configuration.